### PR TITLE
Include human-readable name

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,49 +4,31 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_FILE=$3
 
-PROFILE_PATH="$BUILD_DIR/.profile.d/geoip.sh"
-set-env() {
-  echo "export $1=$2" >> $PROFILE_PATH
-}
-
 GEOIP_VERSION="1.6.9"
 
-VENDORED_GEOIP="vendor/geoip/1.6.0"
-APP_GEOIP="/app/$VENDORED_GEOIP"
+# Download GeoIP.tar.gz
+GEOIP_URL="https://github.com/maxmind/geoip-api-c/releases/download/v$GEOIP_VERSION/GeoIP-$GEOIP_VERSION.tar.gz"
+GEOIP_ARCHAIVE="$CACHE_DIR/GeoIP.tar.gz"
+curl -s -L -o $GEOIP_ARCHAIVE $GEOIP_URL
 
-# Maxmind GeoIP C library
+# Extract GeoIP.dat to $CACHE_DIR/$GEOIP_DAT
+GEOIP_DAT="GeoIP-$GEOIP_VERSION/data/GeoIP.dat"
+tar -zxf $GEOIP_ARCHAIVE -C $CACHE_DIR $GEOIP_DAT
+rm -r $GEOIP_ARCHAIVE
+GEOIP_DAT="$CACHE_DIR/$GEOIP_DAT"
 
-GEOIP_DIST_URL="https://github.com/maxmind/geoip-api-c/releases/download/v$GEOIP_VERSION/GeoIP-$GEOIP_VERSION.tar.gz"
-GEOIP_DIST_DIR="GeoIP-$GEOIP_VERSION"
+# Move GeoIP.dat to $BUILD_DIR subfolder
+NEW_GEOIP_DAT="$BUILD_DIR/vendor/GeoIP.dat"
+mv $GEOIP_DAT $NEW_GEOIP_DAT
+GEOIP_DAT=$NEW_GEOIP_DAT
+rm -rf "$CACHE_DIR/GEOIP-$GEOIP_VERSION"
 
-GEOLITECITY_URL="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz"
-GEOLITECITY_FILE="GeoLite2-City.mmdb"
+# Set enviroment variables
+function set_env {
+  mkdir -p "$BUILD_DIR/.profile.d"
+  echo "export $1=$2" >> "$BUILD_DIR/.profile.d/geoip.sh"
+  export $1=$2
+}
 
-
-#echo "-----> Installing Maxmind GeoIP C Library $GEOIP_VERSION"
-if [ ! -d "$CACHE_DIR/.geoip/$GEOIP_VERSION" ]; then
-    mkdir -p $CACHE_DIR/.geoip/$GEOIP_VERSION
-fi
-
-cd $CACHE_DIR/.geoip/$GEOIP_VERSION
-
-#curl -s -L -o geoip.tar.gz $GEOIP_DIST_URL
-#tar -zxvf geoip.tar.gz > /dev/null
-#cd $GEOIP_DIST_DIR
-#./configure --prefix="$APP_GEOIP" > /dev/null
-#make install --prefix="$BUILD_DIR/$VENDORED_GEOIP" > /dev/null
-
-cd $CACHE_DIR/.geoip/
-if [ ! -f $GEOLITECITY_FILE ]; then
-    curl -s -L -o ${GEOLITECITY_FILE}.gz $GEOLITECITY_URL
-    gunzip ${GEOLITECITY_FILE}.gz > /dev/null
-fi
-mkdir -p "$BUILD_DIR/$VENDORED_GEOIP/share/"
-cp $GEOLITECITY_FILE "$BUILD_DIR/$VENDORED_GEOIP/share/$GEOLITECITY_FILE"
-
-#set-env LIBRARY_PATH "\$LIBRARY_PATH:$APP_GEOIP/lib"
-#set-env LD_LIBRARY_PATH "\$LD_LIBRARY_PATH:$APP_GEOIP/lib"
-#set-env CPATH "\$CPATH:$APP_GEOIP/include"
-
-set-env GEOIP_PATH "$APP_GEOIP/share/"
-echo "       GeoIP City Database is available via env in \$GEOIP_PATH"
+set_env GEOIP_DAT $GEOIP_DAT
+echo "       GeoIP.dat is available via env in \$GEOIP_DAT = $GEOIP_DAT"

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,7 @@ set-env() {
   echo "export $1=$2" >> $PROFILE_PATH
 }
 
-GEOIP_VERSION="1.6.0"
+GEOIP_VERSION="1.6.9"
 
 VENDORED_GEOIP="vendor/geoip/1.6.0"
 APP_GEOIP="/app/$VENDORED_GEOIP"

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 # always install
+echo "GeoIP"
 exit 0


### PR DESCRIPTION
According to [Heroku doc](https://devcenter.heroku.com/articles/buildpack-api#bin-detect-summary) `detect` file must print human-readable framework name to stdout.
